### PR TITLE
fix(docker): add libgomp1 to runtime dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ RUN apt-get update && apt-get install -y \
     ca-certificates \
     curl \
     python3 \
+    libgomp1 \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app


### PR DESCRIPTION
## Problem

The `zeta-server` binary requires `libgomp` (GNU OpenMP runtime library) which was missing from the runtime stage of the Dockerfile. This causes the container to fail on startup with:

```
/app/zeta-server: error while loading shared libraries: libgomp.so.1: cannot open shared object file: No such file or directory
```

## Solution

Added `libgomp1` to the runtime dependencies in the Dockerfile.

## Testing

Verified the container starts successfully after this fix with multiple GPUs